### PR TITLE
fix:用户没有任何二级菜单权限时，出现顶级菜单

### DIFF
--- a/DncZeus.Api/Controllers/AccountController.cs
+++ b/DncZeus.Api/Controllers/AccountController.cs
@@ -129,7 +129,7 @@ WHERE P.IsDeleted=0 AND P.Status=1 AND P.Type=0 AND M.IsDeleted=0 AND M.Status=1
                 {
                     continue;
                 }
-                menus.Add(root);
+                if(menus.Exists(x=>x.ParentGuid == root.Guid)) menus.Add(root);
             }
             menus = menus.OrderBy(x => x.Sort).ThenBy(x=>x.CreatedOn).ToList();
             var menu = MenuItemHelper.LoadMenuTree(menus, "0");


### PR DESCRIPTION
用户二级菜单没有权限时，顶级菜单会出现，点击就显示空白